### PR TITLE
fix(generator): emit valid c# for systemtextjson body + support record types

### DIFF
--- a/src/ZeroAlloc.Serialisation.Generator/SerializerEmitter.cs
+++ b/src/ZeroAlloc.Serialisation.Generator/SerializerEmitter.cs
@@ -14,7 +14,7 @@ internal static class SerializerEmitter
             "MessagePack" =>
                 "global::MessagePack.MessagePackSerializer.Serialize(writer, value);",
             "SystemTextJson" =>
-                "{ using var _jw = new global::System.Text.Json.Utf8JsonWriter(writer); global::System.Text.Json.JsonSerializer.Serialize(_jw, value); }",
+                "using var _jw = new global::System.Text.Json.Utf8JsonWriter(writer);\n        global::System.Text.Json.JsonSerializer.Serialize(_jw, value);",
             _ => throw new System.InvalidOperationException($"Unknown format: {model.FormatName}"),
         };
 
@@ -46,7 +46,9 @@ internal static class SerializerEmitter
             {{ns}}internal sealed class {{model.TypeName}}Serializer : ISerializer<{{model.FullTypeName}}>
             {
                 public void Serialize(IBufferWriter<byte> writer, {{model.FullTypeName}} value)
-                    => {{serializerCall}}
+                {
+                    {{serializerCall}}
+                }
 
                 public {{model.FullTypeName}}? Deserialize(ReadOnlySpan<byte> buffer)
                 {

--- a/src/ZeroAlloc.Serialisation.Generator/SerializerGenerator.cs
+++ b/src/ZeroAlloc.Serialisation.Generator/SerializerGenerator.cs
@@ -15,7 +15,7 @@ public sealed class SerializerGenerator : IIncrementalGenerator
             .ForAttributeWithMetadataName(
                 AttributeFullName,
                 predicate: static (node, _) =>
-                    node is ClassDeclarationSyntax or StructDeclarationSyntax,
+                    node is TypeDeclarationSyntax,
                 transform: static (ctx, ct) => ModelExtractor.Extract(ctx, ct))
             .Where(static m => m is not null)
             .Select(static (m, _) => m!);

--- a/tests/ZeroAlloc.Serialisation.Generator.Tests/RecordAndJsonBugTests.cs
+++ b/tests/ZeroAlloc.Serialisation.Generator.Tests/RecordAndJsonBugTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace ZeroAlloc.Serialisation.Generator.Tests;
+
+public sealed class RecordAndJsonBugTests
+{
+    [Fact]
+    public void SystemTextJson_GeneratesValidBody_WithNoSyntaxErrors()
+    {
+        var source = """
+            using ZeroAlloc.Serialisation;
+            namespace Demo;
+            [ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+            public sealed class WeatherResponse
+            {
+                public string City { get; set; } = "";
+                public double TemperatureC { get; set; }
+            }
+            """;
+
+        var (generated, diagnostics) = Generate(source);
+        Assert.DoesNotContain(diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("public void Serialize", generated, System.StringComparison.Ordinal);
+        // Must NOT be an expression body with a block expression (invalid C#)
+        Assert.DoesNotContain("=> {", generated, System.StringComparison.Ordinal);
+        // Compiling the generated source with the original must succeed
+        AssertGeneratedCompiles(source);
+    }
+
+    [Fact]
+    public void RecordClass_GeneratesSerializer()
+    {
+        var source = """
+            using ZeroAlloc.Serialisation;
+            namespace Demo;
+            [ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+            public sealed record class WeatherResponseRecord(string City, double TemperatureC);
+            """;
+
+        var (generated, _) = Generate(source);
+        Assert.Contains("WeatherResponseRecordSerializer", generated, System.StringComparison.Ordinal);
+        Assert.Contains("ISerializer<Demo.WeatherResponseRecord>", generated, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RecordStruct_GeneratesSerializer()
+    {
+        var source = """
+            using ZeroAlloc.Serialisation;
+            namespace Demo;
+            [ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+            public readonly record struct PointRecord(int X, int Y);
+            """;
+
+        var (generated, _) = Generate(source);
+        Assert.Contains("PointRecordSerializer", generated, System.StringComparison.Ordinal);
+    }
+
+    private static (string generated, IReadOnlyList<Diagnostic> diagnostics) Generate(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var driver = CSharpGeneratorDriver.Create(new SerializerGenerator())
+            .RunGenerators(compilation);
+
+        var result = driver.GetRunResult();
+        var combined = string.Join(
+            "\n\n",
+            result.GeneratedTrees.Select(static t => t.GetText().ToString()));
+        return (combined, result.Diagnostics.ToArray());
+    }
+
+    private static void AssertGeneratedCompiles(string originalSource)
+    {
+        var compilation = CreateCompilation(originalSource);
+        var driver = CSharpGeneratorDriver.Create(new SerializerGenerator())
+            .RunGenerators(compilation);
+
+        var result = driver.GetRunResult();
+
+        // Compile only the per-type serializer output (not DI/Dispatcher which require
+        // Microsoft.Extensions.DependencyInjection at runtime). This is the file that
+        // historically contained the invalid `=> { ... }` expression body.
+        var serializerTrees = result.GeneratedTrees
+            .Where(static t => t.FilePath.EndsWith("Serializer.g.cs", System.StringComparison.Ordinal)
+                && !t.FilePath.Contains("SerializerDispatcher", System.StringComparison.Ordinal)
+                && !t.FilePath.Contains("Extensions", System.StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(serializerTrees);
+
+        // Synthesize global usings that the generator assumes are present (the hosting
+        // project enables ImplicitUsings; the generator output relies on `System` being
+        // in scope for `ReadOnlySpan<byte>`).
+        const string GlobalUsings = "global using System;\n";
+
+        var allTrees = new List<SyntaxTree>(serializerTrees)
+        {
+            CSharpSyntaxTree.ParseText(originalSource),
+            CSharpSyntaxTree.ParseText(GlobalUsings),
+        };
+
+        var references = BuildReferences();
+        var fullCompilation = CSharpCompilation.Create(
+            "FullCompileTest",
+            allTrees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        var allDiagnostics = fullCompilation.GetDiagnostics();
+        Assert.DoesNotContain(allDiagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = BuildReferences();
+
+        return CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static List<MetadataReference> BuildReferences()
+    {
+        var zeroAllocRef = MetadataReference.CreateFromFile(
+            typeof(ZeroAlloc.Serialisation.ZeroAllocSerializableAttribute).Assembly.Location);
+
+        return new List<MetadataReference>(Basic.Reference.Assemblies.Net100.References.All)
+        {
+            zeroAllocRef,
+        };
+    }
+}


### PR DESCRIPTION
Fixes #7 and covers the record-type gap called out in #8.

## Changes
- SerializerEmitter: switch Serialize body from expression-body to block body; SystemTextJson call simplified to statements (not a nested block)
- SerializerGenerator: widen syntax predicate from `ClassDeclarationSyntax or StructDeclarationSyntax` to `TypeDeclarationSyntax` so `record class` and `record struct` are picked up. `[ZeroAllocSerializable]` already restricts targets to class+struct via `AttributeUsage` so no extra parser filtering needed.

## Tests
- `SystemTextJson_GeneratesValidBody_WithNoSyntaxErrors` — generator output compiles without CS errors
- `RecordClass_GeneratesSerializer`
- `RecordStruct_GeneratesSerializer`

## Closes
- #7 (SystemTextJson invalid C#)
- #8 partial (record shape coverage — the remaining edge cases in #8 are separate work)