### PR TITLE
test: comprehensive edge-case coverage for runtime + generator shapes

### DIFF
--- a/tests/ZeroAlloc.Serialisation.Generator.Tests/SerializerShapeCoverageTests.cs
+++ b/tests/ZeroAlloc.Serialisation.Generator.Tests/SerializerShapeCoverageTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace ZeroAlloc.Serialisation.Generator.Tests;
+
+// Covers generator output shapes not exercised by SerializerGeneratorTests or
+// RecordAndJsonBugTests: nested types, global-namespace types, partial classes
+// split across multiple source files, and open-generic type behaviour.
+public sealed class SerializerShapeCoverageTests
+{
+    [Fact]
+    public void NestedType_GeneratesSerializer()
+    {
+        var source = """
+            using ZeroAlloc.Serialisation;
+            namespace Demo;
+            public class Outer
+            {
+                [ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+                public sealed class Inner { public string Name { get; set; } = ""; }
+            }
+            """;
+
+        var (generated, diagnostics) = Generate(source);
+
+        Assert.DoesNotContain(diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("InnerSerializer", generated, System.StringComparison.Ordinal);
+        // Inner's full type name must carry the outer type so the generated code
+        // compiles even when the nested type is referenced from the enclosing namespace.
+        Assert.Contains("Demo.Outer.Inner", generated, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GlobalNamespaceType_GeneratesSerializer()
+    {
+        var source = """
+            using ZeroAlloc.Serialisation;
+            [ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+            public sealed class Unnamespaced { public string V { get; set; } = ""; }
+            """;
+
+        var (generated, diagnostics) = Generate(source);
+
+        Assert.DoesNotContain(diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("UnnamespacedSerializer", generated, System.StringComparison.Ordinal);
+        // Guard against a stray `namespace ;` emission when the source type lives
+        // in the global namespace (the `else ""` branch must suppress the declaration).
+        Assert.DoesNotContain("namespace ;", generated, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PartialClassAcrossFiles_GeneratesSingleSerializer()
+    {
+        var sources = new[]
+        {
+            """
+            using ZeroAlloc.Serialisation;
+            namespace Demo;
+            [ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+            public partial class SplitPoco { public string A { get; set; } = ""; }
+            """,
+            """
+            namespace Demo;
+            public partial class SplitPoco { public int B { get; set; } }
+            """,
+        };
+
+        var result = GenerateFromMultiple(sources);
+
+        Assert.DoesNotContain(result.Diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+        var serializerHints = result.GeneratedTrees
+            .Where(t => t.FilePath.Contains("SplitPocoSerializer.g.cs", System.StringComparison.Ordinal))
+            .ToArray();
+        Assert.Single(serializerHints);
+    }
+
+    // Current behaviour for open generics is undefined — the generator emits a
+    // serializer referencing the open type (e.g. Demo.Wrapper<T>), which is not
+    // valid runtime code. Skip the assertion until a dedicated diagnostic is added
+    // (see issue #8). Keeping the test (skipped) documents the edge case.
+    [Fact(Skip = "open generics: future diagnostic (issue #8)")]
+    public void GenericOpenType_EmitsDiagnosticOrSkipsEmission()
+    {
+        var source = """
+            using ZeroAlloc.Serialisation;
+            namespace Demo;
+            [ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+            public sealed class Wrapper<T> { public T? Value { get; set; } }
+            """;
+
+        var (_, diagnostics) = Generate(source);
+        Assert.DoesNotContain(diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static (string generated, IReadOnlyList<Diagnostic> diagnostics) Generate(string source)
+        => GeneratorTestHost.Generate(source);
+
+    private static GeneratorDriverRunResult GenerateFromMultiple(string[] sources)
+        => GeneratorTestHost.GenerateFromMultiple(sources);
+}
+
+internal static class GeneratorTestHost
+{
+    public static (string generated, IReadOnlyList<Diagnostic> diagnostics) Generate(string source)
+    {
+        var compilation = CreateCompilation(new[] { source });
+        var driver = CSharpGeneratorDriver.Create(new SerializerGenerator())
+            .RunGenerators(compilation);
+
+        var result = driver.GetRunResult();
+        var combined = string.Join(
+            "\n\n",
+            result.GeneratedTrees.Select(static t => t.GetText().ToString()));
+        return (combined, result.Diagnostics.ToArray());
+    }
+
+    public static GeneratorDriverRunResult GenerateFromMultiple(string[] sources)
+    {
+        var compilation = CreateCompilation(sources);
+        var driver = CSharpGeneratorDriver.Create(new SerializerGenerator())
+            .RunGenerators(compilation);
+        return driver.GetRunResult();
+    }
+
+    private static CSharpCompilation CreateCompilation(string[] sources)
+    {
+        var trees = sources.Select(static s => CSharpSyntaxTree.ParseText(s)).ToArray();
+        var zeroAllocRef = MetadataReference.CreateFromFile(
+            typeof(ZeroAlloc.Serialisation.ZeroAllocSerializableAttribute).Assembly.Location);
+
+        var references = new List<MetadataReference>(Basic.Reference.Assemblies.Net100.References.All)
+        {
+            zeroAllocRef,
+        };
+
+        return CSharpCompilation.Create(
+            "TestAssembly",
+            trees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/tests/ZeroAlloc.Serialisation.Tests/SerializerEdgeCaseTests.cs
+++ b/tests/ZeroAlloc.Serialisation.Tests/SerializerEdgeCaseTests.cs
@@ -1,0 +1,295 @@
+using System.Buffers;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using MemoryPack;
+using MessagePack;
+using Xunit;
+using ZeroAlloc.Serialisation.MemoryPack;
+using ZeroAlloc.Serialisation.MessagePack;
+using ZeroAlloc.Serialisation.SystemTextJson;
+
+namespace ZeroAlloc.Serialisation.Tests;
+
+// Anchor types for edge-case coverage. Each is scoped to a single format so round-trip
+// behaviour can be asserted independently. Basic Deserialize(empty-span) and minimal
+// round-trip assertions are already covered in the per-format *SerializerTests.cs files;
+// tests here exercise cases those files do not: richer shapes, nulls, unicode, buffer
+// growth and concurrency.
+
+[ZeroAllocSerializable(SerializationFormat.SystemTextJson)]
+public sealed class StjOrder
+{
+    public string Id { get; set; } = "";
+    public decimal Total { get; set; }
+    public DateTimeOffset PlacedAt { get; set; }
+    public string[]? Tags { get; set; }
+}
+
+[JsonSerializable(typeof(StjOrder))]
+internal partial class StjOrderContext : JsonSerializerContext { }
+
+[MemoryPackable]
+[ZeroAllocSerializable(SerializationFormat.MemoryPack)]
+public partial class MpOrder
+{
+    public string Id { get; set; } = "";
+    public decimal Total { get; set; }
+    public string[]? Tags { get; set; }
+}
+
+[MessagePackObject]
+[ZeroAllocSerializable(SerializationFormat.MessagePack)]
+public class MsgpOrder
+{
+    [Key(0)] public string Id { get; set; } = "";
+    [Key(1)] public decimal Total { get; set; }
+    [Key(2)] public string[]? Tags { get; set; }
+}
+
+public class SerializerEdgeCaseTests
+{
+    // ── Round-trip with richer shape (decimal, DateTimeOffset, list) ──────────
+
+    [Fact]
+    public void Stj_RichShape_RoundTrip()
+    {
+        var serializer = new SystemTextJsonSerializer<StjOrder>(StjOrderContext.Default.StjOrder);
+        var original = new StjOrder
+        {
+            Id = "ord-1",
+            Total = 12345.6789m,
+            PlacedAt = new DateTimeOffset(2026, 4, 22, 12, 0, 0, TimeSpan.FromHours(2)),
+            Tags = new[] { "a", "b" },
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, original);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.NotNull(result);
+        Assert.Equal(original.Id, result.Id);
+        Assert.Equal(original.Total, result.Total);
+        Assert.Equal(original.PlacedAt, result.PlacedAt);
+        Assert.Equal(original.Tags, result.Tags);
+    }
+
+    [Fact]
+    public void MemoryPack_RichShape_RoundTrip()
+    {
+        var serializer = new MemoryPackSerializer<MpOrder>();
+        var original = new MpOrder
+        {
+            Id = "ord-2",
+            Total = 999.99m,
+            Tags = new[] { "x", "y", "z" },
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, original);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.NotNull(result);
+        Assert.Equal(original.Id, result.Id);
+        Assert.Equal(original.Total, result.Total);
+        Assert.Equal(original.Tags, result.Tags);
+    }
+
+    [Fact]
+    public void MessagePack_RichShape_RoundTrip()
+    {
+        var serializer = new MessagePackSerializer<MsgpOrder>();
+        var original = new MsgpOrder
+        {
+            Id = "ord-3",
+            Total = 42.5m,
+            Tags = new[] { "one", "two" },
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, original);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.NotNull(result);
+        Assert.Equal(original.Id, result.Id);
+        Assert.Equal(original.Total, result.Total);
+        Assert.Equal(original.Tags, result.Tags);
+    }
+
+    // ── Null value serialize/deserialize per format ───────────────────────────
+
+    [Fact]
+    public void Stj_NullValue_RoundTripsAsNull()
+    {
+        var serializer = new SystemTextJsonSerializer<StjOrder>(StjOrderContext.Default.StjOrder);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, null!);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void MemoryPack_NullValue_RoundTripsAsNull()
+    {
+        var serializer = new MemoryPackSerializer<MpOrder>();
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, null!);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void MessagePack_NullValue_RoundTripsAsNull()
+    {
+        var serializer = new MessagePackSerializer<MsgpOrder>();
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, null!);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.Null(result);
+    }
+
+    // ── Unicode + control chars (STJ-focused) ─────────────────────────────────
+
+    [Fact]
+    public void Stj_UnicodeAndControlChars_RoundTrip()
+    {
+        var serializer = new SystemTextJsonSerializer<StjOrder>(StjOrderContext.Default.StjOrder);
+        const string TrickyId = "rocket hello\tworld\n\"quoted\" /slash/ éè 中文";
+        var original = new StjOrder
+        {
+            Id = TrickyId,
+            Total = 1m,
+            PlacedAt = DateTimeOffset.UnixEpoch,
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, original);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.NotNull(result);
+        Assert.Equal(TrickyId, result.Id);
+    }
+
+    // ── Very large payload (buffer growth) ────────────────────────────────────
+
+    [Fact]
+    public void Stj_LargePayload_RoundTrip()
+    {
+        var serializer = new SystemTextJsonSerializer<StjOrder>(StjOrderContext.Default.StjOrder);
+        var original = new StjOrder { Id = new string('x', 10_000), Total = 1m, PlacedAt = DateTimeOffset.UnixEpoch };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, original);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.NotNull(result);
+        Assert.Equal(10_000, result.Id.Length);
+    }
+
+    [Fact]
+    public void MemoryPack_LargePayload_RoundTrip()
+    {
+        var serializer = new MemoryPackSerializer<MpOrder>();
+        var tags = new string[5_000];
+        for (var i = 0; i < tags.Length; i++) tags[i] = $"tag-{i}";
+        var original = new MpOrder { Id = "big", Total = 0m, Tags = tags };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, original);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tags);
+        Assert.Equal(5_000, result.Tags!.Length);
+        Assert.Equal("tag-4999", result.Tags![4_999]);
+    }
+
+    [Fact]
+    public void MessagePack_LargePayload_RoundTrip()
+    {
+        var serializer = new MessagePackSerializer<MsgpOrder>();
+        var tags = new string[5_000];
+        for (var i = 0; i < tags.Length; i++) tags[i] = $"tag-{i}";
+        var original = new MsgpOrder { Id = "big", Total = 0m, Tags = tags };
+        var buffer = new ArrayBufferWriter<byte>();
+
+        serializer.Serialize(buffer, original);
+        var result = serializer.Deserialize(buffer.WrittenSpan);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tags);
+        Assert.Equal(5_000, result.Tags!.Length);
+        Assert.Equal("tag-4999", result.Tags![4_999]);
+    }
+
+    // ── Thread safety: 16 tasks x 100 iterations per format ───────────────────
+
+    [Fact]
+    public async Task Stj_ConcurrentRoundTrips_Succeed()
+    {
+        var serializer = new SystemTextJsonSerializer<StjOrder>(StjOrderContext.Default.StjOrder);
+        await RunConcurrentRoundTrips(i =>
+        {
+            var original = new StjOrder { Id = $"ord-{i}", Total = i, PlacedAt = DateTimeOffset.UnixEpoch };
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(buffer, original);
+            var result = serializer.Deserialize(buffer.WrittenSpan);
+            Assert.NotNull(result);
+            Assert.Equal($"ord-{i}", result!.Id);
+        });
+    }
+
+    [Fact]
+    public async Task MemoryPack_ConcurrentRoundTrips_Succeed()
+    {
+        var serializer = new MemoryPackSerializer<MpOrder>();
+        await RunConcurrentRoundTrips(i =>
+        {
+            var original = new MpOrder { Id = $"ord-{i}", Total = i };
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(buffer, original);
+            var result = serializer.Deserialize(buffer.WrittenSpan);
+            Assert.NotNull(result);
+            Assert.Equal($"ord-{i}", result!.Id);
+        });
+    }
+
+    [Fact]
+    public async Task MessagePack_ConcurrentRoundTrips_Succeed()
+    {
+        var serializer = new MessagePackSerializer<MsgpOrder>();
+        await RunConcurrentRoundTrips(i =>
+        {
+            var original = new MsgpOrder { Id = $"ord-{i}", Total = i };
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(buffer, original);
+            var result = serializer.Deserialize(buffer.WrittenSpan);
+            Assert.NotNull(result);
+            Assert.Equal($"ord-{i}", result!.Id);
+        });
+    }
+
+    private static async Task RunConcurrentRoundTrips(Action<int> action)
+    {
+        const int TaskCount = 16;
+        const int PerTask = 100;
+        var tasks = new Task[TaskCount];
+        for (var t = 0; t < TaskCount; t++)
+        {
+            var taskIndex = t;
+            tasks[t] = Task.Run(() =>
+            {
+                for (var i = 0; i < PerTask; i++)
+                {
+                    action((taskIndex * PerTask) + i);
+                }
+            });
+        }
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
Partial resolution of #8.

Adds test coverage for items that were never exercised:

## Runtime (SerializerEdgeCaseTests)
- Round-trip per format with richer shape (decimal, DateTimeOffset, arrays)
- Null value handling per format
- Unicode + control chars in STJ strings
- Buffer growth with a large payload (~10k char string / 5k item array)
- Thread safety (16-task x 100-iteration concurrency per format)

## Generator (SerializerShapeCoverageTests)
- Nested type (inner class inside outer)
- Type in the global namespace (guards against `namespace ;` emission)
- Partial class across multiple source files (single serializer emitted)
- Generic open type (behaviour documented, test skipped pending diagnostic)

## Not in this PR (remaining #8 items)
- New diagnostics (ZASZxxx) — separate PR touches generator code
- AOT / trimming verification — needs a separate test project
- Snapshot tests across every format x shape combo — low priority
- netstandard2.1 fallback coverage

## Test count

Before: 39 passing (26 runtime + 13 generator)
After: 55 passing + 1 skipped (39 runtime + 16 generator + 1 open-generic skip)

Skipped test documents the current undefined behaviour for open generics
and is unskipped when a diagnostic is added (future work).