### PR TITLE
feat: bundle source generator into ZeroAlloc.Serialisation package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Works with [MemoryPack](https://github.com/Cysharp/MemoryPack), [MessagePack](ht
 
 ## Install
 
-```bash
-# Core interface
-dotnet add package ZeroAlloc.Serialisation
+The source generator is bundled into the main package — a single `PackageReference` is all you need:
 
-# Source generator (add as analyzer — no runtime dependency)
-dotnet add package ZeroAlloc.Serialisation.Generator
+```bash
+# Core interface + bundled source generator
+dotnet add package ZeroAlloc.Serialisation
 
 # Pick your backend(s)
 dotnet add package ZeroAlloc.Serialisation.MemoryPack
@@ -25,12 +24,7 @@ dotnet add package ZeroAlloc.Serialisation.MessagePack
 dotnet add package ZeroAlloc.Serialisation.SystemTextJson
 ```
 
-Add the generator as an analyzer in your `.csproj`:
-
-```xml
-<PackageReference Include="ZeroAlloc.Serialisation.Generator" Version="*"
-                  OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-```
+> The standalone `ZeroAlloc.Serialisation.Generator` package is still published for backwards compatibility with existing direct PackageReferences, but new consumers should reference only `ZeroAlloc.Serialisation`.
 
 ## Quick Start
 

--- a/src/ZeroAlloc.Serialisation/ZeroAlloc.Serialisation.csproj
+++ b/src/ZeroAlloc.Serialisation/ZeroAlloc.Serialisation.csproj
@@ -9,4 +9,25 @@
     <Compile Remove="SystemTextJsonFallbackDispatcher.cs" />
     <Compile Remove="SerializerDispatcherFallbackExtensions.cs" />
   </ItemGroup>
+
+  <!--
+    Bundle the source generator into the NuGet package so consumers get it by
+    referencing only ZeroAlloc.Serialisation. The standalone
+    ZeroAlloc.Serialisation.Generator package is still published for backwards
+    compatibility, but new consumers should reference the main package only.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\ZeroAlloc.Serialisation.Generator\ZeroAlloc.Serialisation.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+  <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)..\ZeroAlloc.Serialisation.Generator\bin\$(Configuration)\netstandard2.0\ZeroAlloc.Serialisation.Generator.dll"
+            Pack="true"
+            PackagePath="analyzers/dotnet/cs"
+            Visible="false" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
Until now consumers had to install both `ZeroAlloc.Serialisation` and `ZeroAlloc.Serialisation.Generator` (with the right `OutputItemType` / `PrivateAssets` flags) to get a working setup. Bundling the generator DLL inside the main library's NuGet package under `analyzers/dotnet/cs/` means **a single `PackageReference` is now enough**.

`ZeroAlloc.Serialisation.Generator` continues to publish as a standalone package for backwards compatibility with existing direct `PackageReference`s. New consumers should reference only `ZeroAlloc.Serialisation`.

## What changes
- Add `<ProjectReference ... OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />` to the Generator project (dev-time wiring)
- Add `IncludeGeneratorInPackage` MSBuild target that packs the generator DLL under `analyzers/dotnet/cs/` in the main library's nupkg

## Test plan
- [ ] CI green
- [ ] `dotnet pack` produces `ZeroAlloc.Serialisation.nupkg` containing the generator DLL at `analyzers/dotnet/cs/`
- [ ] In a fresh project with only `<PackageReference Include="ZeroAlloc.Serialisation">`, a `[ZeroAllocSerializable]`-attributed type produces generated `ISerializer<T>` code
- [ ] Existing setups with both packages referenced continue to work (Roslyn dedupes same-version analyzers)

Related: ZeroAlloc-Net/ZeroAlloc.Rest#67

🤖 Generated with [Claude Code](https://claude.com/claude-code)