### PR TITLE
ci: remove auto-publish to nuget on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
           dotnet pack src/ZeroAlloc.Serialisation.MessagePack/ZeroAlloc.Serialisation.MessagePack.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Serialisation.SystemTextJson/ZeroAlloc.Serialisation.SystemTextJson.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
 
-      - name: Push to NuGet (pre-release)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
   aot-smoke:
     runs-on: ubuntu-latest
     # ubuntu-latest is fine for Native AOT on net10.0 — no cross-compile needed.


### PR DESCRIPTION
## Summary
- Removed the `Push to NuGet (pre-release)` step from `.github/workflows/ci.yml` that published all 5 sibling packages on every push to `main`.
- Build, test, and pack steps remain intact; release-please will continue to shepherd actual releases.

## Why
Per org-wide decision: NO pre-release pushes to NuGet. Only release-please-shepherded releases publish.

## Test plan
- [ ] CI workflow still builds, tests, and packs all 5 packages on push/PR
- [ ] No `dotnet nuget push` step runs on push to `main`
- [ ] Release-please flow remains the sole path to NuGet

Generated with [Claude Code](https://claude.com/claude-code)