### PR TITLE
ci: switch release-please to manifest mode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,8 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "release-type": "simple"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

- The `release-please-action` step was invoked with `release-type: simple` inline, which makes the action ignore `release-please-config.json` and `.release-please-manifest.json` entirely. Configured `changelog-sections` and the pinned `2.1.0` baseline were not being honoured.
- Switch to manifest mode by passing `config-file: release-please-config.json` and `manifest-file: .release-please-manifest.json` to the action (mirrors the fix from ZeroAlloc.Mediator PR #68).
- Drop the `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` flags from the config — this package is post-2.0 (latest stable on NuGet is `2.1.0`) so those pre-major flags are no-ops and misleading.

## Notes

This repo ships 5 packages (Serialisation, Generator, MemoryPack, MessagePack, SystemTextJson) released in lockstep, but is currently tracked in release-please as a single-package layout (`.`). Converting to a true multi-package manifest layout is a separate future cleanup; this PR is scoped to fixing the ignored-config bug only.

Manifest version is unchanged (`{".": "2.1.0"}`) and already matches the latest stable on NuGet.

## Test plan

- [ ] After merge, confirm the next release-please run picks up the config (changelog sections rendered as configured).
- [ ] Confirm the next release PR proposes a version bumped from `2.1.0` according to conventional commits.

Generated with [Claude Code](https://claude.com/claude-code)