### PR TITLE
chore(aot-smoke): cover V1 value-object + JsonContext paths

### DIFF
--- a/samples/ZeroAlloc.Serialisation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/Program.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Buffers;
+using System.Text.Json;
 using ZeroAlloc.Serialisation;
 using ZeroAlloc.Serialisation.AotSmoke;
+using ZeroAlloc.Serialisation.SystemTextJson;
 
-// Round-trip all three formats under PublishAot=true. Since #15 landed, the
-// SystemTextJson path now routes through a [JsonSerializable]-sourced
-// JsonTypeInfo<T> — no reflection, no JsonSerializerOptions.Default fallback.
+// Round-trip all three V0 [ZeroAllocSerializable] formats under PublishAot=true.
+// Since #15 landed, the SystemTextJson path routes through a [JsonSerializable]-
+// sourced JsonTypeInfo<T> — no reflection, no JsonSerializerOptions.Default
+// fallback.
 
 var stj = new StjMessage { Id = "stj-1", Value = 42 };
 var mp = new MpMessage { Id = "mp-1", Value = 99 };
@@ -23,8 +26,52 @@ var msgpBuf = new ArrayBufferWriter<byte>();
 new MsgpMessageSerializer().Serialize(msgpBuf, msgp);
 var msgpBack = new MsgpMessageSerializer().Deserialize(msgpBuf.WrittenSpan);
 
-var ok = string.Equals(stjBack?.Id, stj.Id, StringComparison.Ordinal)
+var v0Ok = string.Equals(stjBack?.Id, stj.Id, StringComparison.Ordinal)
     && string.Equals(mpBack?.Id, mp.Id, StringComparison.Ordinal)
     && string.Equals(msgpBack?.Id, msgp.Id, StringComparison.Ordinal);
-Console.WriteLine(ok ? "AOT smoke: PASS" : "AOT smoke: FAIL");
-return ok ? 0 : 1;
+
+// V1 value-object path under PublishAot=true + JsonSerializerContext. This is
+// the surface the templates exercise: a [ValueObject] embedded in a DTO that
+// the source-gen-emitted JsonTypeInfo walks at startup. Without 2.3.2's
+// per-assembly IJsonTypeInfoResolver, options.GetTypeInfo(ValueObjectId)
+// throws NotSupportedException("metadata not provided") because JsonContext
+// can't see the [JsonConverter] attribute that ZA's generator adds via a
+// partial-struct extension (gens can't see each other's output).
+var jsonOptions = new JsonSerializerOptions
+{
+    TypeInfoResolver = ValueObjectDtoContext.Default,
+};
+jsonOptions.AddZeroAllocValueObjectConverters();
+
+// 2.3.2 invariant: typeinfo for the value-object resolves through the
+// per-assembly resolver inserted by the registrar.
+var voTypeInfo = jsonOptions.GetTypeInfo(typeof(ValueObjectId));
+var resolverWired = voTypeInfo is not null && voTypeInfo.Type == typeof(ValueObjectId);
+
+// 2.3.1 + 2.3.2 invariant: the DTO round-trips with bare-integer wire format.
+// If the resolver returned JsonContext's broken stub instead of ours, this
+// would write {"Id":{"Value":42},"Label":"x"} and the bare-integer assertion
+// would fail.
+var dto = new ValueObjectDto(new ValueObjectId(42), "alpha");
+var dtoJson = JsonSerializer.Serialize(dto, jsonOptions);
+var bareIntegerWire = dtoJson.Contains("\"Id\":42", StringComparison.Ordinal)
+    && !dtoJson.Contains("\"value\"", StringComparison.OrdinalIgnoreCase)
+    && !dtoJson.Contains("\"Value\"", StringComparison.Ordinal);
+
+var dtoBack = JsonSerializer.Deserialize<ValueObjectDto>(dtoJson, jsonOptions);
+var roundTrip = dtoBack is not null
+    && dtoBack.Id.Value == dto.Id.Value
+    && string.Equals(dtoBack.Label, dto.Label, StringComparison.Ordinal);
+
+var v1Ok = resolverWired && bareIntegerWire && roundTrip;
+
+var ok = v0Ok && v1Ok;
+if (!ok)
+{
+    Console.WriteLine($"AOT smoke: FAIL (v0={v0Ok}, resolver={resolverWired}, wire={bareIntegerWire}, roundTrip={roundTrip})");
+    Console.WriteLine($"  dtoJson={dtoJson}");
+    return 1;
+}
+
+Console.WriteLine("AOT smoke: PASS");
+return 0;

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/Program.cs
@@ -52,13 +52,22 @@ var resolverWired = voTypeInfo is not null && voTypeInfo.Type == typeof(ValueObj
 // If the resolver returned JsonContext's broken stub instead of ours, this
 // would write {"Id":{"Value":42},"Label":"x"} and the bare-integer assertion
 // would fail.
+// Use the source-gen-typeinfo overloads of Serialize/Deserialize so the
+// smoke compiles cleanly under <WarningsAsErrors>IL2026;IL3050;...</WarningsAsErrors>
+// (the options-based JsonSerializer.Serialize<T>(value, options) overload
+// triggers IL2026 + IL3050 because it walks reflection at compile-time
+// analysis even when the runtime resolver is source-gen-backed). The
+// typeinfo path STILL respects options.Converters (the 2.3.1 registrar's
+// Converters.Add precedence flows through GetConverter), so the test
+// invariants are preserved.
 var dto = new ValueObjectDto(new ValueObjectId(42), "alpha");
-var dtoJson = JsonSerializer.Serialize(dto, jsonOptions);
+var customContext = new ValueObjectDtoContext(jsonOptions);
+var dtoJson = JsonSerializer.Serialize(dto, customContext.ValueObjectDto);
 var bareIntegerWire = dtoJson.Contains("\"Id\":42", StringComparison.Ordinal)
     && !dtoJson.Contains("\"value\"", StringComparison.OrdinalIgnoreCase)
     && !dtoJson.Contains("\"Value\"", StringComparison.Ordinal);
 
-var dtoBack = JsonSerializer.Deserialize<ValueObjectDto>(dtoJson, jsonOptions);
+var dtoBack = JsonSerializer.Deserialize(dtoJson, customContext.ValueObjectDto);
 var roundTrip = dtoBack is not null
     && dtoBack.Id.Value == dto.Id.Value
     && string.Equals(dtoBack.Label, dto.Label, StringComparison.Ordinal);

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDto.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDto.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+// Container DTO mirroring the shape the templates use: a record carrying a
+// typed-ID property. Without the 2.3.1 registrar + 2.3.2 resolver, the
+// JsonSerializerContext source-gen path would either write {"id":{"value":42}}
+// (wrong wire format) or throw NotSupportedException at startup when ASP.NET
+// Core walks the property graph and asks for typeinfo for ValueObjectId.
+public sealed record ValueObjectDto(ValueObjectId Id, string Label);

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDtoContext.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDtoContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+// The JsonSerializerContext that exposes the value-object container DTO to
+// STJ's source-gen. Note: ValueObjectId is intentionally NOT in this context's
+// [JsonSerializable] list — under the 2.3.2 design the per-assembly resolver
+// is responsible for providing its typeinfo, and the registration would mask
+// regressions in the resolver path.
+[JsonSerializable(typeof(ValueObjectDto))]
+internal partial class ValueObjectDtoContext : JsonSerializerContext { }

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectId.cs
@@ -8,20 +8,21 @@ namespace ZeroAlloc.ValueObjects
     public sealed class ValueObjectAttribute : System.Attribute { }
 }
 
-namespace ZeroAlloc.Serialisation.AotSmoke;
-
-// V1 value-object fixture: [ValueObject] partial struct wrapping a single
-// primitive. The generator emits:
-//   - A partial extension carrying [JsonConverter(typeof(...))]
-//   - An internal sealed ValueObjectIdSystemTextJsonConverter class
-//   - A per-assembly registrar (ValueObjectJsonConvertersExtensions)
-//   - A per-assembly JsonTypeInfoResolver (2.3.2)
-//
-// All four must survive Native AOT publish + the trimmer's reachability
-// analysis for the wire format to come out bare-integer at runtime.
-[ZeroAlloc.ValueObjects.ValueObject]
-public readonly partial struct ValueObjectId
+namespace ZeroAlloc.Serialisation.AotSmoke
 {
-    public int Value { get; }
-    public ValueObjectId(int value) => Value = value;
+    // V1 value-object fixture: [ValueObject] partial struct wrapping a single
+    // primitive. The generator emits:
+    //   - A partial extension carrying [JsonConverter(typeof(...))]
+    //   - An internal sealed ValueObjectIdSystemTextJsonConverter class
+    //   - A per-assembly registrar (ValueObjectJsonConvertersExtensions)
+    //   - A per-assembly JsonTypeInfoResolver (2.3.2)
+    //
+    // All four must survive Native AOT publish + the trimmer's reachability
+    // analysis for the wire format to come out bare-integer at runtime.
+    [ZeroAlloc.ValueObjects.ValueObject]
+    public readonly partial struct ValueObjectId
+    {
+        public int Value { get; }
+        public ValueObjectId(int value) => Value = value;
+    }
 }

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectId.cs
@@ -1,0 +1,27 @@
+// Stub the [ValueObjectAttribute] inline. The generator FQN-matches the
+// attribute by name and doesn't depend on the ZeroAlloc.ValueObjects package's
+// runtime semantics; keeping the smoke project self-contained avoids
+// version-pinning a sibling repo just to exercise this code path.
+namespace ZeroAlloc.ValueObjects
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+    public sealed class ValueObjectAttribute : System.Attribute { }
+}
+
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+// V1 value-object fixture: [ValueObject] partial struct wrapping a single
+// primitive. The generator emits:
+//   - A partial extension carrying [JsonConverter(typeof(...))]
+//   - An internal sealed ValueObjectIdSystemTextJsonConverter class
+//   - A per-assembly registrar (ValueObjectJsonConvertersExtensions)
+//   - A per-assembly JsonTypeInfoResolver (2.3.2)
+//
+// All four must survive Native AOT publish + the trimmer's reachability
+// analysis for the wire format to come out bare-integer at runtime.
+[ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct ValueObjectId
+{
+    public int Value { get; }
+    public ValueObjectId(int value) => Value = value;
+}

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ZeroAlloc.Serialisation.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ZeroAlloc.Serialisation.AotSmoke.csproj
@@ -30,6 +30,13 @@
     <ProjectReference Include="..\..\src\ZeroAlloc.Serialisation\ZeroAlloc.Serialisation.csproj"
                       SetTargetFramework="TargetFramework=net10.0"
                       UndefineProperties="PublishAot" />
+    <!-- The generator's V1 value-object pipeline (2.3.0-2.3.2) gates emission on
+         a reference to the SystemTextJson backend assembly. Adding it here both
+         brings the AddZeroAllocValueObjectConverters extension method into scope
+         and trips the gate so the registrar + resolver actually get emitted. -->
+    <ProjectReference Include="..\..\src\ZeroAlloc.Serialisation.SystemTextJson\ZeroAlloc.Serialisation.SystemTextJson.csproj"
+                      SetTargetFramework="TargetFramework=net10.0"
+                      UndefineProperties="PublishAot" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Serialisation.Generator\ZeroAlloc.Serialisation.Generator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"


### PR DESCRIPTION
## Summary

Extends the existing `aot-smoke` job's smoke project to exercise the V1 (`[ValueObject]`) emission paths added in 2.3.0 / 2.3.1 / 2.3.2. The 2.3.1 and 2.3.2 patches both shipped reactively because downstream templates discovered AOT gaps that this smoke should have caught — those gaps live on a different code path than what the V0-only smoke covered.

## What the existing smoke covered

- V0 path: `[ZeroAllocSerializable]` → `XSerializer.Serialize/Deserialize` on `ArrayBufferWriter<byte>`
- No JsonSerializerContext, no `[ValueObject]`, no registrar, no resolver

## What this PR adds

- `ValueObjectId` partial struct (`[ZeroAlloc.ValueObjects.ValueObject]`, attribute stubbed inline to keep the smoke self-contained)
- `ValueObjectDto` record carrying the typed ID
- `ValueObjectDtoContext : JsonSerializerContext` registering the DTO only (NOT the value-object — that's the resolver's job)
- Program.cs assertions:
  - `options.GetTypeInfo(typeof(ValueObjectId)) is not null` (load-bearing for 2.3.2 — this exact call is what ASP.NET Core's request-delegate factory makes at startup)
  - JSON serialize produces `"Id":42` and NOT `"value"` / `"Value"` (load-bearing for 2.3.1 + 2.3.2 wire-format invariant)
  - Round-trip restores the DTO with semantic fidelity

The csproj gains a project reference to `ZeroAlloc.Serialisation.SystemTextJson` so the generator's STJ-backend gate fires and the registrar + resolver actually get emitted.

## Why this matters

A regression in any of:
- Converter class emission (V1)
- `[JsonConverter]` attribute on the partial-struct extension (V1)
- `AddZeroAllocValueObjectConverters` registrar emission (2.3.1)
- `Converters.Add` precedence at serialize time (2.3.1)
- `IJsonTypeInfoResolver` class emission (2.3.2)
- `TypeInfoResolverChain.Insert(0, ...)` in the registrar body (2.3.2)
- Trimmer reachability of any of the above

...now fails the `aot-smoke` job. Previously, all six gaps were silently bypassed because the smoke didn't touch this code path.

## SemVer

No package version change — this is purely CI hygiene. release-please will treat it as `chore:` and skip the release manifest.

## Test plan

- [ ] CI green
- [ ] Follow-up: org-wide survey ([report](#)) identified thin smoke coverage in ZA.Inject, ZA.Validation, ZA.AsyncEvents — separate backlog items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)