### PR TITLE
feat(generator): extend value-object serialization to 6 common underlying types

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -25,11 +25,18 @@ Multi-property value-objects (`Money { Amount, Currency }`) fall through silentl
 
 ---
 
-## V2 — Extend MessagePack underlying-type table to cover Guid/DateTime
+## ~~V2 — Extend MessagePack underlying-type table to cover Guid/DateTime~~ — ✅ shipped 2.4.0
+
+**Shipped:** Both serializer switches (`MessagePackReadWriteForType` and `SystemTextJsonReadWriteForType`) now cover the full set of common underlying types beyond the bare primitives: `Guid`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `decimal`, `byte[]`. MessagePack uses resolver dispatch (`MessagePackSerializer.Serialize<T>` / `Deserialize<T>`) for consistency and to respect adopter-registered custom formatters. STJ uses the native `Utf8JsonReader.GetXxx` / `Utf8JsonWriter.WriteXxxValue` methods where they exist, with `TimeSpan.Parse(reader.GetString()!)` as the read path for `TimeSpan` and `value.ToString()` on the write side for the same reason (no `WriteStringValue(TimeSpan)` overload). MemoryPack's emit was already type-agnostic via `ReadValue<T>` / `WriteValue<T>` — no change needed there.
+
+**Regression coverage:** `samples/ZeroAlloc.Serialisation.AotSmoke/` gained six fixtures (`ValueObjectGuidId`, `ValueObjectDateTimeId`, `ValueObjectDateTimeOffsetId`, `ValueObjectTimeSpanId`, `ValueObjectDecimalId`, `ValueObjectBytesId`) plus direct converter/formatter round-trip assertions in `Program.cs`. The aot-smoke CI check fails if any of the six types regress.
+
+<details>
+<summary>Original V2 proposal (kept for context)</summary>
 
 **Surfaced during V1 code-review** (2026-05-27): `ValueObjectEmitter.MessagePackReadWriteForType` falls through to `reader.ReadString()!` for any underlying type outside `Int16/32/64`, `Single/Double`, `Boolean`, `String`. STJ's sibling already handles `Guid` and `DateTime` explicitly. The asymmetry means an adopter who tries `[ValueObject] struct OrderId { Guid Value }` with both STJ + MessagePack referenced will compile under STJ but hit a `CS1503` under MessagePack (`Guid` has no `string` ctor).
 
-**Why deferred:** V1 spec was int-only; no template currently demands `Guid`-shaped IDs. Surfaces immediately the moment one does. Single-method-table extension; ~5 lines + a snapshot test.
+</details>
 
 ---
 

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/Program.cs
@@ -109,12 +109,135 @@ var mpRoundTrip = mpDtoBack is not null
 
 var v2Ok = mpBareInteger && mpRoundTrip;
 
-var ok = v0Ok && v1Ok && v2Ok;
+// V2 underlying-type coverage smoke (shipped 2.4.0): the generator's
+// MessagePackReadWriteForType + SystemTextJsonReadWriteForType switches now
+// cover Guid, DateTime, DateTimeOffset, TimeSpan, decimal, byte[] beyond the
+// bare primitives. Each [ValueObject] fixture below has both an STJ converter
+// and a MessagePack formatter emitted by the generator; we invoke them
+// directly (instead of through JsonSerializerContext / GeneratedMessagePackResolver)
+// so the smoke focuses on the per-type read/write emit shape — without
+// requiring 6 extra [JsonSerializable] entries on ValueObjectDtoContext or
+// 6 extra [MessagePackObject] DTO wrappers. The 2.3.x context/resolver
+// integration paths are already covered by the v1Ok/v2Ok blocks above.
+var underlyingOk = true;
+var underlyingFailures = new System.Collections.Generic.List<string>();
+
+static bool TryStj<T>(System.Text.Json.Serialization.JsonConverter<T> converter, T input, System.Func<T, T, bool> equals, out string failure)
+{
+    failure = "";
+    try
+    {
+        var buf = new ArrayBufferWriter<byte>();
+        using (var w = new System.Text.Json.Utf8JsonWriter(buf))
+        {
+            converter.Write(w, input, new JsonSerializerOptions());
+        }
+        var reader = new System.Text.Json.Utf8JsonReader(buf.WrittenSpan);
+        reader.Read();
+        var back = converter.Read(ref reader, typeof(T), new JsonSerializerOptions());
+        if (!equals(input, back))
+        {
+            failure = $"stj round-trip mismatch for {typeof(T).Name}: wire={System.Text.Encoding.UTF8.GetString(buf.WrittenSpan)}";
+            return false;
+        }
+        return true;
+    }
+    catch (Exception ex)
+    {
+        failure = $"stj threw {ex.GetType().Name} for {typeof(T).Name}: {ex.Message}";
+        return false;
+    }
+}
+
+static bool TryMp<T>(global::MessagePack.Formatters.IMessagePackFormatter<T> formatter, T input, System.Func<T, T, bool> equals, out string failure)
+{
+    failure = "";
+    try
+    {
+        var buf = new ArrayBufferWriter<byte>();
+        var writer = new global::MessagePack.MessagePackWriter(buf);
+        formatter.Serialize(ref writer, input, global::MessagePack.MessagePackSerializerOptions.Standard);
+        writer.Flush();
+        var reader = new global::MessagePack.MessagePackReader(buf.WrittenMemory);
+        var back = formatter.Deserialize(ref reader, global::MessagePack.MessagePackSerializerOptions.Standard);
+        if (!equals(input, back))
+        {
+            failure = $"mp round-trip mismatch for {typeof(T).Name}";
+            return false;
+        }
+        return true;
+    }
+    catch (Exception ex)
+    {
+        failure = $"mp threw {ex.GetType().Name} for {typeof(T).Name}: {ex.Message}";
+        return false;
+    }
+}
+
+// Guid
+{
+    var input = new ValueObjectGuidId(Guid.NewGuid());
+    if (!TryStj(new ValueObjectGuidIdSystemTextJsonConverter(), input, (a, b) => a.Value == b.Value, out var f1))
+    { underlyingOk = false; underlyingFailures.Add(f1); }
+    if (!TryMp(new ValueObjectGuidIdMessagePackFormatter(), input, (a, b) => a.Value == b.Value, out var f2))
+    { underlyingOk = false; underlyingFailures.Add(f2); }
+}
+
+// DateTime
+{
+    var input = new ValueObjectDateTimeId(new DateTime(2026, 6, 10, 12, 34, 56, DateTimeKind.Utc));
+    if (!TryStj(new ValueObjectDateTimeIdSystemTextJsonConverter(), input, (a, b) => a.Value == b.Value, out var f1))
+    { underlyingOk = false; underlyingFailures.Add(f1); }
+    if (!TryMp(new ValueObjectDateTimeIdMessagePackFormatter(), input, (a, b) => a.Value == b.Value, out var f2))
+    { underlyingOk = false; underlyingFailures.Add(f2); }
+}
+
+// DateTimeOffset
+{
+    var input = new ValueObjectDateTimeOffsetId(new DateTimeOffset(2026, 6, 10, 12, 34, 56, TimeSpan.FromHours(2)));
+    if (!TryStj(new ValueObjectDateTimeOffsetIdSystemTextJsonConverter(), input, (a, b) => a.Value == b.Value, out var f1))
+    { underlyingOk = false; underlyingFailures.Add(f1); }
+    if (!TryMp(new ValueObjectDateTimeOffsetIdMessagePackFormatter(), input, (a, b) => a.Value == b.Value, out var f2))
+    { underlyingOk = false; underlyingFailures.Add(f2); }
+}
+
+// TimeSpan
+{
+    var input = new ValueObjectTimeSpanId(TimeSpan.FromMinutes(42.5));
+    if (!TryStj(new ValueObjectTimeSpanIdSystemTextJsonConverter(), input, (a, b) => a.Value == b.Value, out var f1))
+    { underlyingOk = false; underlyingFailures.Add(f1); }
+    if (!TryMp(new ValueObjectTimeSpanIdMessagePackFormatter(), input, (a, b) => a.Value == b.Value, out var f2))
+    { underlyingOk = false; underlyingFailures.Add(f2); }
+}
+
+// decimal
+{
+    var input = new ValueObjectDecimalId(12345.6789m);
+    if (!TryStj(new ValueObjectDecimalIdSystemTextJsonConverter(), input, (a, b) => a.Value == b.Value, out var f1))
+    { underlyingOk = false; underlyingFailures.Add(f1); }
+    if (!TryMp(new ValueObjectDecimalIdMessagePackFormatter(), input, (a, b) => a.Value == b.Value, out var f2))
+    { underlyingOk = false; underlyingFailures.Add(f2); }
+}
+
+// byte[]
+{
+    var input = new ValueObjectBytesId(new byte[] { 1, 2, 3, 4, 5, 42, 99 });
+    if (!TryStj(new ValueObjectBytesIdSystemTextJsonConverter(), input, (a, b) => a.Value.AsSpan().SequenceEqual(b.Value), out var f1))
+    { underlyingOk = false; underlyingFailures.Add(f1); }
+    if (!TryMp(new ValueObjectBytesIdMessagePackFormatter(), input, (a, b) => a.Value.AsSpan().SequenceEqual(b.Value), out var f2))
+    { underlyingOk = false; underlyingFailures.Add(f2); }
+}
+
+var ok = v0Ok && v1Ok && v2Ok && underlyingOk;
 if (!ok)
 {
-    Console.WriteLine($"AOT smoke: FAIL (v0={v0Ok}, v1.resolver={resolverWired}, v1.wire={bareIntegerWire}, v1.roundTrip={roundTrip}, v2.bareInt={mpBareInteger}, v2.roundTrip={mpRoundTrip})");
+    Console.WriteLine($"AOT smoke: FAIL (v0={v0Ok}, v1.resolver={resolverWired}, v1.wire={bareIntegerWire}, v1.roundTrip={roundTrip}, v2.bareInt={mpBareInteger}, v2.roundTrip={mpRoundTrip}, underlying={underlyingOk})");
     Console.WriteLine($"  dtoJson={dtoJson}");
     Console.WriteLine($"  mpJson={mpJson}");
+    foreach (var failure in underlyingFailures)
+    {
+        Console.WriteLine($"  underlying: {failure}");
+    }
     return 1;
 }
 

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectBytesId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectBytesId.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+[ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct ValueObjectBytesId
+{
+    public byte[] Value { get; }
+    public ValueObjectBytesId(byte[] value) => Value = value;
+}

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDateTimeId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDateTimeId.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+[ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct ValueObjectDateTimeId
+{
+    public System.DateTime Value { get; }
+    public ValueObjectDateTimeId(System.DateTime value) => Value = value;
+}

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDateTimeOffsetId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDateTimeOffsetId.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+[ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct ValueObjectDateTimeOffsetId
+{
+    public System.DateTimeOffset Value { get; }
+    public ValueObjectDateTimeOffsetId(System.DateTimeOffset value) => Value = value;
+}

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDecimalId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectDecimalId.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+[ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct ValueObjectDecimalId
+{
+    public decimal Value { get; }
+    public ValueObjectDecimalId(decimal value) => Value = value;
+}

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectGuidId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectGuidId.cs
@@ -1,0 +1,11 @@
+// V2 underlying-type-coverage smoke: Guid-backed [ValueObject]. Exercises the
+// resolver-dispatch arm in MessagePackReadWriteForType + the GetGuid/WriteStringValue
+// arm in SystemTextJsonReadWriteForType.
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+[ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct ValueObjectGuidId
+{
+    public System.Guid Value { get; }
+    public ValueObjectGuidId(System.Guid value) => Value = value;
+}

--- a/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectTimeSpanId.cs
+++ b/samples/ZeroAlloc.Serialisation.AotSmoke/ValueObjectTimeSpanId.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.Serialisation.AotSmoke;
+
+[ZeroAlloc.ValueObjects.ValueObject]
+public readonly partial struct ValueObjectTimeSpanId
+{
+    public System.TimeSpan Value { get; }
+    public ValueObjectTimeSpanId(System.TimeSpan value) => Value = value;
+}

--- a/src/ZeroAlloc.Serialisation.Generator/ValueObjectEmitter.cs
+++ b/src/ZeroAlloc.Serialisation.Generator/ValueObjectEmitter.cs
@@ -45,6 +45,13 @@ internal static class ValueObjectEmitter
         var (readMethod, writeMethod) = SystemTextJsonReadWriteForType(underlying.Type);
         var converterName = $"{typeName}SystemTextJsonConverter";
 
+        // STJ's Utf8JsonWriter has no WriteStringValue(TimeSpan) overload — TimeSpan
+        // round-trips through ToString() / Parse(). For all other underlying types
+        // the native overload accepts the property type directly.
+        var writeArgExpr = string.Equals(underlying.Type.ToDisplayString(), "System.TimeSpan", StringComparison.Ordinal)
+            ? $"value.{underlying.Name}.ToString()"
+            : $"value.{underlying.Name}";
+
         var nsOpen = string.IsNullOrEmpty(ns) ? "" : $"namespace {ns};\n\n";
 
         return $$"""
@@ -66,7 +73,7 @@ internal static class ValueObjectEmitter
                     => new {{typeName}}({{readMethod}});
 
                 public override void Write(Utf8JsonWriter writer, {{typeName}} value, JsonSerializerOptions options)
-                    => writer.{{writeMethod}}(value.{{underlying.Name}});
+                    => writer.{{writeMethod}}({{writeArgExpr}});
             }
 
             """;
@@ -175,7 +182,13 @@ internal static class ValueObjectEmitter
         var ns = type.ContainingNamespace.IsGlobalNamespace ? "" : type.ContainingNamespace.ToDisplayString();
         var typeKindKeyword = type.IsRecord ? "record struct" : "struct";
         var readonlyKeyword = type.IsReadOnly ? "readonly " : "";
-        var (readMethod, _) = MessagePackReadWriteForType(underlying.Type);
+        var (readMethod, writeArgFormat) = MessagePackReadWriteForType(underlying.Type);
+        // WriteArgFormat now carries a full C# statement template (e.g. "writer.Write({0})"
+        // or "MessagePackSerializer.Serialize<T>(ref writer, {0}, options)") — the {0}
+        // placeholder is substituted with the property access. This keeps each switch
+        // arm self-contained so the per-type write path (primitive write vs resolver
+        // dispatch) lives in one place.
+        var writeStatement = string.Format(System.Globalization.CultureInfo.InvariantCulture, writeArgFormat, $"value.{underlying.Name}");
         var formatterName = $"{typeName}MessagePackFormatter";
 
         var nsOpen = string.IsNullOrEmpty(ns) ? "" : $"namespace {ns};\n\n";
@@ -195,7 +208,7 @@ internal static class ValueObjectEmitter
             internal sealed class {{formatterName}} : IMessagePackFormatter<{{typeName}}>
             {
                 public void Serialize(ref MessagePackWriter writer, {{typeName}} value, MessagePackSerializerOptions options)
-                    => writer.Write(value.{{underlying.Name}});
+                    => {{writeStatement}};
 
                 public {{typeName}} Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
                     => new {{typeName}}({{readMethod}});
@@ -348,16 +361,40 @@ internal static class ValueObjectEmitter
 
     private static (string ReadCall, string WriteArgFormat) MessagePackReadWriteForType(ITypeSymbol underlyingType)
     {
+        // WriteArgFormat is a full C# statement template — {0} is substituted with
+        // the property access (e.g. "value.Value"). Primitives use the native
+        // MessagePackWriter.Write(...) overloads; everything else routes through
+        // MessagePackSerializer.Serialize<T>(ref writer, value, options) so the
+        // active resolver's formatter (incl. adopter-registered custom formatters)
+        // is honoured. Symmetric on the read side via Deserialize<T>.
         return underlyingType.SpecialType switch
         {
-            SpecialType.System_Int32   => ("reader.ReadInt32()",   "{0}"),
-            SpecialType.System_Int64   => ("reader.ReadInt64()",   "{0}"),
-            SpecialType.System_Int16   => ("reader.ReadInt16()",   "{0}"),
-            SpecialType.System_Single  => ("reader.ReadSingle()",  "{0}"),
-            SpecialType.System_Double  => ("reader.ReadDouble()",  "{0}"),
-            SpecialType.System_Boolean => ("reader.ReadBoolean()", "{0}"),
-            SpecialType.System_String  => ("reader.ReadString()!", "{0}"),
-            _ => ("reader.ReadString()!", "{0}"),
+            SpecialType.System_Int32   => ("reader.ReadInt32()",   "writer.Write({0})"),
+            SpecialType.System_Int64   => ("reader.ReadInt64()",   "writer.Write({0})"),
+            SpecialType.System_Int16   => ("reader.ReadInt16()",   "writer.Write({0})"),
+            SpecialType.System_Single  => ("reader.ReadSingle()",  "writer.Write({0})"),
+            SpecialType.System_Double  => ("reader.ReadDouble()",  "writer.Write({0})"),
+            SpecialType.System_Boolean => ("reader.ReadBoolean()", "writer.Write({0})"),
+            SpecialType.System_String  => ("reader.ReadString()!", "writer.Write({0})"),
+            SpecialType.System_Decimal
+                => ("MessagePackSerializer.Deserialize<decimal>(ref reader, options)",
+                    "MessagePackSerializer.Serialize<decimal>(ref writer, {0}, options)"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "System.Guid", StringComparison.Ordinal)
+                => ("MessagePackSerializer.Deserialize<global::System.Guid>(ref reader, options)",
+                    "MessagePackSerializer.Serialize<global::System.Guid>(ref writer, {0}, options)"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "System.DateTime", StringComparison.Ordinal)
+                => ("MessagePackSerializer.Deserialize<global::System.DateTime>(ref reader, options)",
+                    "MessagePackSerializer.Serialize<global::System.DateTime>(ref writer, {0}, options)"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "System.DateTimeOffset", StringComparison.Ordinal)
+                => ("MessagePackSerializer.Deserialize<global::System.DateTimeOffset>(ref reader, options)",
+                    "MessagePackSerializer.Serialize<global::System.DateTimeOffset>(ref writer, {0}, options)"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "System.TimeSpan", StringComparison.Ordinal)
+                => ("MessagePackSerializer.Deserialize<global::System.TimeSpan>(ref reader, options)",
+                    "MessagePackSerializer.Serialize<global::System.TimeSpan>(ref writer, {0}, options)"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "byte[]", StringComparison.Ordinal)
+                => ("MessagePackSerializer.Deserialize<byte[]>(ref reader, options)",
+                    "MessagePackSerializer.Serialize<byte[]>(ref writer, {0}, options)"),
+            _ => ("reader.ReadString()!", "writer.Write({0})"),
         };
     }
 
@@ -377,6 +414,17 @@ internal static class ValueObjectEmitter
                 => ("reader.GetGuid()", "WriteStringValue"),
             _ when string.Equals(underlyingType.ToDisplayString(), "System.DateTime", StringComparison.Ordinal)
                 => ("reader.GetDateTime()", "WriteStringValue"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "System.DateTimeOffset", StringComparison.Ordinal)
+                => ("reader.GetDateTimeOffset()", "WriteStringValue"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "System.TimeSpan", StringComparison.Ordinal)
+                // Utf8JsonReader has no GetTimeSpan() pre-.NET 7; TimeSpan.Parse(reader.GetString()!)
+                // is safe and round-trips ISO 8601-ish via value.ToString() on the write side
+                // (handled in EmitSystemTextJsonConverter — there's no WriteStringValue(TimeSpan)
+                // overload either, so we materialise the string explicitly).
+                => ("global::System.TimeSpan.Parse(reader.GetString()!)", "WriteStringValue"),
+            _ when string.Equals(underlyingType.ToDisplayString(), "byte[]", StringComparison.Ordinal)
+                // Base64 string encoding matches STJ's default byte[] wire format.
+                => ("reader.GetBytesFromBase64()", "WriteBase64StringValue"),
             _ => ("reader.GetString()!", "WriteStringValue"), // fallback — let the compiler complain if the user's underlying type doesn't accept this
         };
     }


### PR DESCRIPTION
## Summary

Closes V2 in the backlog. Extends the value-object generator's STJ + MessagePack emit to cover `Guid`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `decimal`, `byte[]` underlying types — the standard set beyond bare primitives.

## Background

The MessagePack switch fell through to `reader.ReadString()!` for any non-primitive underlying type → `CS1503` at the value-object constructor whenever an adopter tried `[ValueObject] struct Foo { Guid Value }`. STJ had Guid + DateTime + decimal already; this PR adds DateTimeOffset + TimeSpan + byte[] to keep the two serializers symmetric.

## Approach

- **MessagePack:** all 6 new arms use resolver dispatch (`MessagePackSerializer.Serialize<T>` / `Deserialize<T>`). Idiomatic wire format, respects custom formatters. The emitter is refactored so `WriteArgFormat` now carries a full statement template — primitives use `"writer.Write({0})"`, the new arms use the resolver-dispatch form.
- **STJ:** native `Utf8JsonReader.GetXxx` / `Utf8JsonWriter.WriteXxxValue` overloads where available. `TimeSpan` uses `TimeSpan.Parse(reader.GetString()!)` on read + `value.ToString()` on write (no `Utf8JsonWriter.WriteStringValue(TimeSpan)` overload). `byte[]` uses base64 encoding (`GetBytesFromBase64` / `WriteBase64StringValue`) matching STJ's default `byte[]` wire format.
- **MemoryPack:** zero emitter changes — the existing `ReadValue<T>` / `WriteValue<T>` generic path already covers everything that has a MemoryPack formatter.

## Regression coverage

Six new aot-smoke fixtures + direct converter/formatter round-trip assertions in `Program.cs`. If any type's emit regresses, the aot-smoke CI check fails before merge.

## Test plan

- [x] All existing tests pass (51 generator + 51 lib = 102 green)
- [x] 6 new aot-smoke fixtures round-trip cleanly through STJ + MessagePack (`AOT smoke: PASS`)
- [x] Primitive-path emit semantically unchanged: `writer.Write(value.Value)` before and after (existing snapshot test asserts the literal substring and still passes)

## Versioning

`feat(generator):` squash → minor bump → 2.4.0 (current release-please manifest pin is 2.3.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)